### PR TITLE
set vagrant hostname to module name to avoid name collision during acceptance testing

### DIFF
--- a/moduleroot/Makefile
+++ b/moduleroot/Makefile
@@ -7,11 +7,17 @@ deps:
 test: deps
 	bundle exec rake test
 
-acceptance: deps
-	bundle exec rake acceptance
-
-inspect: deps
+acceptance: deps vagrant-destroy
 	bundle exec rake acceptance BEAKER_destroy=no;\
-	cd .vagrant/beaker_vagrant_files/default.yml && vagrant ssh;
+	$(MAKE) vagrant-destroy
+
+inspect: deps vagrant-destroy
+	bundle exec rake acceptance BEAKER_destroy=no;\
+	pushd .vagrant/beaker_vagrant_files/default.yml; vagrant ssh; popd
+
+vagrant-destroy:
+	test -d .vagrant && \
+	pushd .vagrant/beaker_vagrant_files/default.yml; vagrant destroy --force; popd;\
+	rm -rf .vagrant;
 
 PHONY: test accpetance inspect clean

--- a/moduleroot/spec/acceptance/nodesets/default.yml
+++ b/moduleroot/spec/acceptance/nodesets/default.yml
@@ -1,5 +1,6 @@
+<% name = @configs['module_metadata']['name'].split('-').last rescue '[modulename]' %>
 HOSTS:
-  vagrant-host01-local-ww00.wellspringworldwide.com:
+  vagrant-<%= name %>01-local-ww00.wellspringworldwide.com:
     roles:
       - master
     platform: el-7-x86_64


### PR DESCRIPTION
When all the vagrant hosts have the same name, acceptance testing gets weird if you don't destroy the box you're working on.