### PR TITLE
pin beaker-vagrant ~> 0.6.2

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -588,7 +588,7 @@ Gemfile:
       - gem: beaker-rspec
         version: '~> 6.2.4'
       - gem: beaker-vagrant
-        version: '~> 0.5.0'
+        version: '~> 0.6.2'
 #.gitlab-ci.yml:
 #  defaults:
 #    cache:


### PR DESCRIPTION
previous version of beaker-vagrant was causing audio driver issues. This was pulled in every time a new module was created with `pdk new module` command(s).